### PR TITLE
Move activesupport to a dev dependency

### DIFF
--- a/cli-template.gemspec
+++ b/cli-template.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "thor"
   spec.add_dependency "rainbow"
-  spec.add_dependency "activesupport"
 
+  spec.add_development_dependency "activesupport"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "guard"

--- a/lib/templates/default/Rakefile.tt
+++ b/lib/templates/default/Rakefile.tt
@@ -9,5 +9,6 @@ require_relative "lib/<%= project_name %>"
 require "cli_markdown"
 desc "Generates cli reference docs as markdown"
 task :docs do
+  mkdir_p "docs/_includes"
   CliMarkdown::Creator.create_all(cli_class: <%= project_class_name %>::CLI, cli_name: "<%= project_name %>")
 end


### PR DESCRIPTION
This is a great starter for Thor.  Thanks for sharing.

2 things I ran into:

1. activesupport.  I saw it is only used by `cli_markdown` so I moved to a dev dependency.  I prefer to avoid it for small projects if possible since the gem is a bit large but YMMV.
2. When generating docs (`rake docs`) `cli_markdown` will fail if the destination directory does not exist.  